### PR TITLE
These creatures should display this item on tooltip when plr has the quest 'Pie for Billy'.

### DIFF
--- a/updates/20230612-1505_quest_pie_for_billy_creature_tooltip.sql
+++ b/updates/20230612-1505_quest_pie_for_billy_creature_tooltip.sql
@@ -1,0 +1,22 @@
+-- Chunk of Boar Meat
+SET @ITEM_ID := 769;
+
+-- Stonetusk Boar:
+SET @NPC_ID1 := 113;
+UPDATE `creature_names` SET `questitem1` = @ITEM_ID WHERE `entry` = @NPC_ID1;
+
+-- Longsnout:
+SET @NPC_ID2 := 119;
+UPDATE `creature_names` SET `questitem1` = @ITEM_ID WHERE `entry` = @NPC_ID2;
+
+-- Rockhide Boar:
+SET @NPC_ID3 := 524;
+UPDATE `creature_names` SET `questitem1` = @ITEM_ID WHERE `entry` = @NPC_ID3;
+
+-- Porcine Entourage:
+SET @NPC_ID4 := 390;
+UPDATE `creature_names` SET `questitem1` = @ITEM_ID WHERE `entry` = @NPC_ID4;
+
+-- Princess:
+SET @NPC_ID5 := 330;
+UPDATE `creature_names` SET `questitem2` = @ITEM_ID WHERE `entry` = @NPC_ID5;


### PR DESCRIPTION
arcemu: d035a6ed545c2b9edd2e4b8c04fb33990e6b75cd
db: 3ed532744a6beaf0503c103f535de0a84a13c399

Item: Chunk of Boar Meat
Creatures: Stonetusk Boar, Rockhide Boar, Longsnout, Princess, Porcine Entourage