### PR TITLE
Updated Collectors Edition quest enders to 3.3.5 spawn position.

### DIFF
--- a/updates/20230613-1535_collector_edition_quest_enders.sql
+++ b/updates/20230613-1535_collector_edition_quest_enders.sql
@@ -1,0 +1,17 @@
+-- Goldshire: Merissa Stillwell
+UPDATE `creature_spawns` SET `position_x` = -9478.9, `position_y` = 49.9652, `position_z` = 57.313, `orientation` = 6.1665 WHERE `entry` = 11940;
+
+-- Kharanos: Yori Crackhelm
+UPDATE `creature_spawns` SET `position_x` = -5592.95, `position_y` = -529.919, `position_z` = 399.653, `orientation` = 1.6284 WHERE `entry` = 11941;
+
+-- Dolanaar: Orenthil Whisperwind
+UPDATE `creature_spawns` SET `position_x` = 9839.59, `position_y` = 945.991, `position_z` = 1307.27, `orientation` = 5.84685 WHERE `entry` = 11942;
+
+-- Razor Hill: Magga
+UPDATE `creature_spawns` SET `position_x` = 327.574, `position_y` = -4682.93, `position_z` = 16.4578, `orientation` = 5.8253 WHERE `entry` = 11943;
+
+-- Brill: Claire Willower
+UPDATE `creature_spawns` SET `position_x` = 2286.34, `position_y` = 247.798, `position_z` = 41.1148, `orientation` = 3.00922 WHERE `entry` = 11945;
+
+-- Bloodhoof Village: Vorn Skyseer
+UPDATE `creature_spawns` SET `position_x` = -2328.49, `position_y` = -382.269, `position_z` = -7.89994, `orientation` = 1.79769 WHERE `entry` = 11944;


### PR DESCRIPTION
arcemu: d035a6ed545c2b9edd2e4b8c04fb33990e6b75cd
db: f8a7cf5908bfdc6b6b9d9325f9cdffce16064692

The following creatures got a new position at 3.3.5

Merissa Stillwell => Goldshire
Yori Crackhelm => Kharanos
Orenthil Whisperwind => Dolanaar
Magga => Magga
Claire Willower => Brill
Vorn Skyseer => Bloodhoof Village