### PR TITLE
Added monstersay entry and ai_agent for Garrick Padfoot.

### DIFF
--- a/updates/20230613-1735_garrick_padfoot_monstersay_ai_agent.sql
+++ b/updates/20230613-1735_garrick_padfoot_monstersay_ai_agent.sql
@@ -1,0 +1,7 @@
+-- Garrick Padfoot: cast "Defensive Stance" on combat, no repeat
+REPLACE INTO `ai_agents` (`entry`, `instance_mode`, `type`, `event`, `chance`, `maxcount`, `spell`, `spelltype`, `targettype_overwrite`, `cooldown_overwrite`, `floatMisc1`, `Misc2`) 
+VALUES (103, 4, 4, 0, 100, 1, 7164, 10, 4, 0, 0, 0);
+
+-- Monstersay on enter combat
+REPLACE INTO `npc_monstersay` (`entry`, `event`, `chance`, `language`, `type`, `monstername`, `text0`, `text1`, `text2`, `text3`, `text4`) 
+VALUES (103, 0, 100, 7, 12, 'Garrick Padfoot', 'This land belongs to the Defias Brotherhood now!', 'I see those fools at the Abbey sent some fresh meat for us.', NULL, NULL, NULL);


### PR DESCRIPTION
arcemu: d035a6ed545c2b9edd2e4b8c04fb33990e6b75cd
db: f8a7cf5908bfdc6b6b9d9325f9cdffce16064692

Garrick Padfoot should cast 'Defensive Stance' when enter combat (one time only)

Also it should chat one of the following texts:

1) "This land belongs to the Defias Brotherhood now!"

2) "I see those fools at the Abbey sent some fresh meat for us."