### PR TITLE
Transport cleanup (northrend turtles)

### DIFF
--- a/updates/20230613-1900_cleanup_transports_turtles.sql
+++ b/updates/20230613-1900_cleanup_transports_turtles.sql
@@ -1,2 +1,5 @@
 -- Dragonblight: delete creatures that should be in transports (turtles)
 DELETE FROM `creature_spawns` WHERE `entry` IN ( 31804, 31805, 31806, 31807 );
+
+-- 31807 even has waypoints
+DELETE FROM `creature_waypoints` WHERE `spawnid` IN ( 128411, 128412 );

--- a/updates/20230613-1900_cleanup_transports_turtles.sql
+++ b/updates/20230613-1900_cleanup_transports_turtles.sql
@@ -1,0 +1,2 @@
+-- Dragonblight: delete creatures that should be in transports (turtles)
+DELETE FROM `creature_spawns` WHERE `entry` IN ( 31804, 31805, 31806, 31807 );


### PR DESCRIPTION
db: f8a7cf5908bfdc6b6b9d9325f9cdffce16064692

These creatures should be spawned at transport but they are at world. Some of them walks through over the air or are double spawned:

Qatiichii
Nagojut
Oomailiq
Aumanil