### PR TITLE
Fixed emote for quest 'Report to Goldshire'. 

### DIFF
--- a/updates/20230615-0442_quest_report_to_goldshire_emote.sql
+++ b/updates/20230615-0442_quest_report_to_goldshire_emote.sql
@@ -1,0 +1,1 @@
+UPDATE `quests` SET `detailemote1` = 113 WHERE `entry` = 54;


### PR DESCRIPTION
db: 3e42616485cb96558f1dc543481e5cfa0a4cb60a

The emote was removed from quest plugin since it can be handle from database but i forget to check if it was there.

https://github.com/arcemu/arcemu/pull/444

