### PR TITLE
Added missing GO - Quest binding for 'Galgars Cactus'.

### DIFF
--- a/updates/20230617-1712_galgars_cactus_binding.sql
+++ b/updates/20230617-1712_galgars_cactus_binding.sql
@@ -1,0 +1,1 @@
+REPLACE INTO gameobject_quest_pickup_binding VALUES( 171938, 4402, 6 );


### PR DESCRIPTION
db: 3e42616485cb96558f1dc543481e5cfa0a4cb60a