### PR TITLE
Changed 'Immolate' coldoown to a more reasonable time.

### DIFF
--- a/updates/20230620-1508_yarrog_baneshadow_immolate_coldoown.sql
+++ b/updates/20230620-1508_yarrog_baneshadow_immolate_coldoown.sql
@@ -1,0 +1,1 @@
+UPDATE `ai_agents` SET `cooldown_overwrite` = 18000 WHERE `entry` = 3183 AND `spell` = 348;


### PR DESCRIPTION
db: 3e42616485cb96558f1dc543481e5cfa0a4cb60a

'Yarrog Baneshadow' its casting 'Immolate' all the time. Changed cooldown to a more reasonable time.

.npc portto 25512