### PR TITLE
Fixed phase for 'Voljin' outside 'Lordaeron Ruins'

### DIFF
--- a/updates/20230627-0500_voljin_bfu_phase.sql
+++ b/updates/20230627-0500_voljin_bfu_phase.sql
@@ -1,0 +1,2 @@
+-- Voljin outside Lordaeron Ruins (related to quest: 'Battle for Undercity')
+UPDATE creature_spawns SET phase = 64 WHERE entry = 31649;


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

This one is related to quest 'Battle for the Undercity'

.npc portto 142546