### PR TITLE
Updated 'Tawny Grisette' spawn coords and fixed movetype

### DIFF
--- a/updates/20230627-0535_tawny_spawn_movetype.sql
+++ b/updates/20230627-0535_tawny_spawn_movetype.sql
@@ -1,0 +1,3 @@
+-- Tawny Grisette (Undercity)
+UPDATE creature_spawns SET position_x = 1622.25, position_y = 263.732, position_z = -43.1027, 
+orientation = 2.32365, movetype = 2 WHERE entry = 4554;


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

She walks on circle inside Undercity

.npc portto 35265