### PR TITLE
Updated 'Maquell Ebonwood' movetype and spawn position.

### DIFF
--- a/updates/20230627-1552_maquell_ebonwood_spawn_movetype.sql
+++ b/updates/20230627-1552_maquell_ebonwood_spawn_movetype.sql
@@ -1,0 +1,3 @@
+-- Maquell Ebonwood (Deathknell)
+UPDATE creature_spawns SET position_x = 1860.44, position_y = 1588.64, position_z = 92.439, 
+orientation = 6.15239, movetype = 2 WHERE entry = 2315;


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

'Maquell Ebonwood' (Deathknell) should circle wp. Also updated spawn position, no more walk through walls.

.npc portto 17480