### PR TITLE
Updated 'Deathguard Phillips' spawn position and movetype.

### DIFF
--- a/updates/20230627-1605_deathguard_phillips_spawn_movetype.sql
+++ b/updates/20230627-1605_deathguard_phillips_spawn_movetype.sql
@@ -1,0 +1,3 @@
+-- Deathguard Phillips (Deathknell)
+UPDATE creature_spawns SET position_x = 1847.25, position_y = 1572.01, position_z = 95.0795, 
+orientation = 4.79961, movetype = 2 WHERE entry = 1739;


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

'Deathguard Phillips' (Deathknell) should circle wp. Also updated spawn position to avoid walk through walls.

.npc porrto 12543