### PR TITLE
Removed GO 'Bright Colored Egg' related to 'Noblegarden' calendar event.

### DIFF
--- a/updates/20230627-1640_go_bright_colored_egg_cleanup.sql
+++ b/updates/20230627-1640_go_bright_colored_egg_cleanup.sql
@@ -1,0 +1,2 @@
+-- GO Bright Colored Eggs (Noblegarden calendar event)
+DELETE FROM gameobject_spawns WHERE Entry = 113772; 


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

Removed 10 eggs from 'Noblegarden' calendar event.