### PR TITLE
Delete from creature_spawns some creatures that should be on transport 'The Maidens Fancy'

### DIFF
--- a/updates/20230707-2233_the_maidens_fance_delete.sql
+++ b/updates/20230707-2233_the_maidens_fance_delete.sql
@@ -1,2 +1,2 @@
 -- The Maidens Fancy
-DELETE FROM creature_spawns WHERE entry IN ( 25082, 25089 );
+DELETE FROM creature_spawns WHERE entry IN ( 25098, 25082, 25089 );

--- a/updates/20230707-2233_the_maidens_fance_delete.sql
+++ b/updates/20230707-2233_the_maidens_fance_delete.sql
@@ -1,2 +1,2 @@
 -- The Maidens Fancy
-DELETE FROM creature_spawns WHERE entry IN ( 25098, 25082, 25089 );
+DELETE FROM creature_spawns WHERE entry IN ( 25082, 25089 );

--- a/updates/20230707-2233_the_maidens_fance_delete.sql
+++ b/updates/20230707-2233_the_maidens_fance_delete.sql
@@ -1,0 +1,2 @@
+-- The Maidens Fancy
+DELETE FROM creature_spawns WHERE entry IN ( 25098, 25082, 25089 );


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

https://www.wowhead.com/wotlk/npc=25098/bosun-thunderhorn
https://www.wowhead.com/wotlk/npc=25082/engineer-torquespindle
https://www.wowhead.com/wotlk/npc=25089/galley-chief-steelbelly

.npc portto 138032
.npc portto 138033
.npc portto 137612
.npc portto 137613