### PR TITLE
Remove two 'Zeppelin Control' from creature_spawns.

### DIFF
--- a/updates/20230707-2349_zeppelin_control_delete.sql
+++ b/updates/20230707-2349_zeppelin_control_delete.sql
@@ -1,0 +1,2 @@
+-- Zeppelin Control
+DELETE FROM creature_spawns WHERE entry = 25075;


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

.npc portto 141498
.npc portto 141499