### PR TITLE
Delete two creatures that should be in transport 'The Lady Mehley'

### DIFF
--- a/updates/20230708-0210_the_lady_mehley_delete.sql
+++ b/updates/20230708-0210_the_lady_mehley_delete.sql
@@ -1,0 +1,2 @@
+-- The Lady Mehley
+DELETE FROM creature_spawns WHERE entry IN ( 24834, 24843 );


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

These two creatures should be onboard 'The Lady Mehley'

https://www.wowhead.com/wotlk/npc=24834/galley-chief-grace
https://www.wowhead.com/wotlk/npc=24843/engineer-combs

.npc portto 138036
.npc portto 137622