### PR TITLE
Removed two creatures that should be onboard 'The Moonspray'.

### DIFF
--- a/updates/20230708-1558_moonspray_delete.sql
+++ b/updates/20230708-1558_moonspray_delete.sql
@@ -1,0 +1,2 @@
+-- The Moonspray
+DELETE FROM creature_spawns WHERE entry IN ( 24993, 24995 );


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

https://www.wowhead.com/wotlk/npc=24993/galley-chief-mariss
https://www.wowhead.com/wotlk/npc=24995/merchant-fallel-stargazer

.npc portto 137621
.npc porrto 137620