### PR TITLE
Removed two creatures that should be on transport 'The Bravery'

### DIFF
--- a/updates/20230708-1610_bravery_delete.sql
+++ b/updates/20230708-1610_bravery_delete.sql
@@ -1,0 +1,2 @@
+-- The Bravery
+DELETE FROM creature_spawns WHERE entry IN ( 25010, 25012 );


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

https://www.wowhead.com/wotlk/npc=25010/engineer-brightbuckle
https://www.wowhead.com/wotlk/npc=25012/galley-chief-gathers

.npc portto 137619
.npc portto 137618