### PR TITLE
Delete two creatures that should be on 'Feathermoon Ferry'

### DIFF
--- a/updates/20230708-2100_feathermoon_ferry_delete.sql
+++ b/updates/20230708-2100_feathermoon_ferry_delete.sql
@@ -1,0 +1,2 @@
+-- Feathermoon Ferry
+DELETE FROM creature_spawns WHERE entry IN ( 25019, 25020 );


### PR DESCRIPTION
db: b2faeda90a89783b05f5e5cffdf9b9a941cff710

https://www.wowhead.com/wotlk/npc=25019/merchant-felagunne
https://www.wowhead.com/wotlk/npc=25020/galley-chief-alunwea

.npc portto 137615
.npc portto 137614