### PR TITLE
Removed four creatures than should be on transport 'Elunes Blessing'.

### DIFF
--- a/updates/20230711-1900_elunes_blessing_delete.sql
+++ b/updates/20230711-1900_elunes_blessing_delete.sql
@@ -1,0 +1,2 @@
+-- 'Elunes Blessing'
+DELETE FROM creature_spawns WHERE entry IN ( 25050, 25051, 25052, 25056 );


### PR DESCRIPTION
db: 42926d3e28730cd6057df0f590d8b80c15aec3fa

Two of them are spawned over the sea :D

https://www.wowhead.com/wotlk/npc=25050/captain-galind-windsword
https://www.wowhead.com/wotlk/npc=25051/merchant-frostwalker
https://www.wowhead.com/wotlk/npc=25052/galley-chief-halumvorea
https://www.wowhead.com/wotlk/npc=25056/mariner-stillglider

.npc portto 138782
.npc portto 137617
.npc portto 137616
.npc portto 138781