### PR TITLE
GO Dirt-strained Map should only start the most recent quest 'Attack on Camp Narache'.

### DIFF
--- a/updates/20230712-0216_go_quest_starter_attack_camp_narache.sql
+++ b/updates/20230712-0216_go_quest_starter_attack_camp_narache.sql
@@ -1,0 +1,2 @@
+-- Dirt-strained Map should only start quest 24857
+DELETE FROM gameobject_quest_starter WHERE id = 3076 AND quest = 781;


### PR DESCRIPTION
db: 42926d3e28730cd6057df0f590d8b80c15aec3fa

Currently it start: 781, 24857

But it should start only 24857

.go portto 16060

