### PR TITLE
Removed some dirt we added previously.

### DIFF
--- a/updates/20230713-1533_cleanup_gameobject_quest_pickup_binding.sql
+++ b/updates/20230713-1533_cleanup_gameobject_quest_pickup_binding.sql
@@ -1,0 +1,4 @@
+-- Remove Quest binding for 'Galgars Cactus'
+DELETE FROM gameobject_quest_pickup_binding WHERE quest = 498;
+-- Remove Quest binding for 'Milly's harvest'
+DELETE FROM gameobject_quest_pickup_binding WHERE quest = 3904;


### PR DESCRIPTION
db: 934972ff391ac315b1aa08b5e1bdd50369e2cf6b

Lets remove this before forget about them:

quests: 'Milly's harvest', 'Galgars Cactus'

https://github.com/arcemu/db/commit/f8a7cf5908bfdc6b6b9d9325f9cdffce16064692
https://github.com/arcemu/db/commit/0d96defd6787caf479c806c97ea98549af2abcf2

¿Dont remember why? Check this:

https://github.com/arcemu/db/discussions/29

